### PR TITLE
Recorder resume

### DIFF
--- a/Tone/component/channel/Recorder.test.ts
+++ b/Tone/component/channel/Recorder.test.ts
@@ -68,6 +68,19 @@ describe("Recorder", () => {
 			rec.dispose();
 		});
 
+		it("can be resumed after pausing", async () => {
+			const rec = new Recorder();
+			rec.start();
+			expect(rec.state).to.equal("started");
+			await wait(100);
+			rec.pause();
+			expect(rec.state).to.equal("paused");
+			await wait(100);
+			rec.start();
+			expect(rec.state).to.equal("started");
+			rec.dispose();
+		});
+
 		it("can be stopped after starting", async () => {
 			const rec = new Recorder();
 			rec.start();

--- a/Tone/component/channel/Recorder.ts
+++ b/Tone/component/channel/Recorder.ts
@@ -107,7 +107,7 @@ export class Recorder extends ToneAudioNode<RecorderOptions> {
 	}
 
 	/**
-	 * Start the Recorder. Returns a promise which resolves
+	 * Start/Resume the Recorder. Returns a promise which resolves
 	 * when the recorder has started.
 	 */
 	async start() {
@@ -121,8 +121,11 @@ export class Recorder extends ToneAudioNode<RecorderOptions> {
 
 			this._recorder.addEventListener("start", handleStart, false);
 		});
-
-		this._recorder.start();
+		if(this.state === "stopped") {
+			this._recorder.start();
+		} else {
+			this._recorder.resume();
+		}
 		return await startPromise;
 	}
 


### PR DESCRIPTION
There is no straightforward way of resuming/unpausing a paused recorder as play() and pause() result in an error and the underlying MediaRecorder is exposed neither.

Resumes recorder by calling start() as per expecation in issue https://github.com/Tonejs/Tone.js/issues/1026.

Tests are successful.
